### PR TITLE
Debugging problem with path separators

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -41,6 +42,7 @@ func LoadConfig(path string) (*Config, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	fmt.Println(cfg.Path)
 	return &cfg, nil
 }
 
@@ -102,7 +104,7 @@ func NewConfigFromFlags() (*Config, []string, bool, error) {
 	var cfg Config
 	var commands multiStringFlag
 	var fileFlags fileMappingFlag
-	
+
 	// Define and parse CLI flags
 	configPath := flag.String("config", "", "Path to config file (optional)")
 	user := flag.String("user", "ubuntu", "SSH username")
@@ -114,7 +116,7 @@ func NewConfigFromFlags() (*Config, []string, bool, error) {
 	output := flag.String("output", "myapp", "Name of output binary")
 	entry := flag.String("entry", "main.go", "Go entry file")
 	generateGitHubAction := flag.Bool("github", false, "Generate GitHub Actions workflow file")
-	
+
 	flag.Var(&commands, "cmd", "Additional commands to run on remote server (can be specified multiple times)")
 	flag.Var(&fileFlags, "file", "Additional files/folders to copy (format: src[:dst], can be specified multiple times)")
 	flag.Parse()

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -22,6 +22,8 @@ func Build(cfg *config.Config, buildDir string) error {
 	}
 
 	outputPath := filepath.Join(buildDir, cfg.Output)
+	fmt.Println("Building Go binary at:", outputPath)
+
 	buildCmd := exec.Command("go", "build", "-o", outputPath, cfg.Entry)
 	buildCmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
 
@@ -31,7 +33,12 @@ func Build(cfg *config.Config, buildDir string) error {
 // DeployBinary copies the binary to the remote server
 func DeployBinary(client *ssh.Client, cfg *config.Config, buildDir string) error {
 	outputPath := filepath.Join(buildDir, cfg.Output)
-	return client.CopyFile(outputPath, filepath.Join(cfg.Path, cfg.Output), true)
+
+	// Join the cfg.Path and cfg.Output to create the remote path
+	// Use filepath.ToSlash to ensure the path is in the correct format for the remote server
+	remotePath := filepath.ToSlash(filepath.Join(cfg.Path, cfg.Output))
+
+	return client.CopyFile(outputPath, remotePath, true)
 }
 
 // DeployFiles copies additional files to the remote server


### PR DESCRIPTION
Post refactor there was a teensy bit of cleaning up to do...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility of remote deployment paths by standardizing path format.
- **Chores**
	- Added debug print statements to aid in troubleshooting configuration loading and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->